### PR TITLE
fix: release internal

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,6 +10,12 @@
         "pkg/catppuccin"
       ]
     },
+    "internal/logtheme": {
+      "component": "logtheme"
+    },
+    "internal/themes": {
+      "component": "themes"
+    },
     "pkg/catppuccin": {
       "component": "catppuccin"
     }

--- a/go.work
+++ b/go.work
@@ -1,8 +1,0 @@
-go 1.21
-
-use (
-	.
-	./internal/logtheme
-	./internal/themes
-	./pkg/catppuccin
-)


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 49da9055ee465797f26d33e609a9ff9643882dbb  | 
|--------|

### Summary:
This PR removes the `go.work` file, affecting workspace configuration for directories like root, `internal/logtheme`, `internal/themes`, and `pkg/catppuccin`.

**Key points**:
- Removed `go.work` file
- Affected directories: `.` (root), `./internal/logtheme`, `./internal/themes`, `./pkg/catppuccin`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
